### PR TITLE
fix: sometimes encode return iolist unexpectedly

### DIFF
--- a/lib/jiffy.ex
+++ b/lib/jiffy.ex
@@ -68,7 +68,9 @@ defmodule Jiffy do
   """
   @spec encode!(any, opts :: :jiffy.encode_option()) :: {:ok, any()} | no_return()
   def encode!(data, opts \\ []) do
-    :jiffy.encode(data, @encode_options ++ opts)
+    data
+    |> :jiffy.encode(@encode_options ++ opts)
+    |> :erlang.iolist_to_binary()
   end
 
   @doc """
@@ -92,7 +94,7 @@ defmodule Jiffy do
       iex> Jiffy.decode("[1,2,3]")
       {:ok, [1, 2, 3]}
   """
-  @spec decode(String.t, opts :: :jiffy.decode_option()) :: {:ok, any()} | {:error, atom()}
+  @spec decode(String.t(), opts :: :jiffy.decode_option()) :: {:ok, any()} | {:error, atom()}
   def decode(data, opts \\ []) do
     {:ok, decode!(data, opts)}
   catch
@@ -109,7 +111,7 @@ defmodule Jiffy do
       iex> Jiffy.decode!("[1,2,3]")
       [1, 2, 3]
   """
-  @spec decode!(String.t, opts :: :jiffy.decode_option()) :: any() | no_return()
+  @spec decode!(String.t(), opts :: :jiffy.decode_option()) :: any() | no_return()
   def decode!(data, opts \\ []) do
     :jiffy.decode(data, @decode_options ++ opts)
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,1 +1,3 @@
-%{"elixir_make": {:hex, :elixir_make, "0.4.0", "992f38fabe705bb45821a728f20914c554b276838433349d4f2341f7a687cddf", [:mix], []}}
+%{
+  "elixir_make": {:hex, :elixir_make, "0.4.0", "992f38fabe705bb45821a728f20914c554b276838433349d4f2341f7a687cddf", [:mix], [], "hexpm", "4549183795460c581fd82010d10862e46bcf796e2039d16c255bad3e408f435d"},
+}


### PR DESCRIPTION
background: https://github.com/davisp/jiffy#usage

   The only thing that might catch you off guard is that
   the return type of jiffy:encode/1 is an iolist
   even though it returns a binary most of the time.

process situations exclude the "most of the time"